### PR TITLE
chore: bump nodejs version to v24

### DIFF
--- a/.github/workflows/deploy-demo-page.yml
+++ b/.github/workflows/deploy-demo-page.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 22
+nodejs 24

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "type": "module",
   "engine": {
-    "node": "^22"
+    "node": "^22 || ^24"
   },
   "scripts": {
     "prepare": "panda codegen --clean",


### PR DESCRIPTION
v24 will be promoted to LTS at the end of October 2025


<img width="759" height="445" alt="NodeJS Website Screenshot" src="https://github.com/user-attachments/assets/71e90f26-8927-4358-a868-8dab3307a863" />

