### PR TITLE
test: expand unit coverage (~85%→~99%) + DST progress fix

### DIFF
--- a/src/boot/localize-html.test.ts
+++ b/src/boot/localize-html.test.ts
@@ -1,0 +1,101 @@
+import type { Chrome } from '@/utils/chrome'
+
+const { chromeMock, getDocumentLanguageMock, getMessageMock } = vi.hoisted(() => ({
+  chromeMock: vi.fn<() => Chrome | undefined>(),
+  getDocumentLanguageMock: vi.fn<() => string>(),
+  getMessageMock: vi.fn<(key: string) => string>(),
+}))
+
+vi.mock('@/utils/chrome', () => ({ default: chromeMock }))
+vi.mock('@/utils/get-document-language', () => ({ default: getDocumentLanguageMock }))
+
+beforeEach(() => {
+  vi.resetModules()
+  getDocumentLanguageMock.mockReturnValue('en')
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+  document.body.innerHTML = ''
+  document.documentElement.lang = ''
+})
+
+describe('localize-html boot', () => {
+  it('sets the document language from getDocumentLanguage', async () => {
+    getDocumentLanguageMock.mockReturnValue('ru')
+
+    await boot()
+
+    expect(document.documentElement.lang).toBe('ru')
+    expect(getDocumentLanguageMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('localizes elements with a data-l key using chrome i18n', async () => {
+    getMessageMock.mockImplementation((key) => (key === 'hello' ? 'Hi' : ''))
+    mockChromeI18n()
+    document.body.innerHTML = '<span data-l="hello">placeholder</span>'
+
+    await boot()
+
+    expect(document.body.querySelector('span')?.innerHTML).toBe('Hi')
+    expect(getMessageMock).toHaveBeenCalledTimes(1)
+    expect(getMessageMock).toHaveBeenCalledWith('hello')
+  })
+
+  it('still sets the language but skips localization when chrome() is undefined', async () => {
+    getDocumentLanguageMock.mockReturnValue('ru')
+    chromeMock.mockReturnValue(undefined)
+    document.body.innerHTML = '<span data-l="hello">original</span>'
+
+    await boot()
+
+    expect(document.body.querySelector('span')?.innerHTML).toBe('original')
+    expect(document.documentElement.lang).toBe('ru')
+  })
+
+  it('skips localization when chrome() exists but i18n is absent', async () => {
+    chromeMock.mockReturnValue({})
+    document.body.innerHTML = '<span data-l="hello">original</span>'
+
+    await boot()
+
+    expect(document.body.querySelector('span')?.innerHTML).toBe('original')
+  })
+
+  it('skips non-HTML elements (SVG) matched by the data attribute', async () => {
+    getMessageMock.mockImplementation((key) => (key === 'hello' ? 'Hi' : 'UNEXPECTED'))
+    mockChromeI18n()
+    const $svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    $svg.setAttribute('data-l', 'hello')
+    $svg.textContent = 'icon'
+    document.body.append($svg)
+
+    await boot()
+
+    expect(document.body.querySelector('svg')?.textContent).toBe('icon')
+    expect(getMessageMock).not.toHaveBeenCalled()
+  })
+
+  it('leaves an element with an empty data-l key untouched while still localizing valid siblings', async () => {
+    getMessageMock.mockImplementation((key) => (key === 'hello' ? 'Hi' : 'UNEXPECTED'))
+    mockChromeI18n()
+    document.body.innerHTML = '<span data-l="">keep me</span><span data-l="hello">placeholder</span>'
+
+    await boot()
+
+    const [$empty, $valid] = document.body.querySelectorAll('span')
+    expect($empty?.innerHTML).toBe('keep me')
+    expect($valid?.innerHTML).toBe('Hi')
+    expect(getMessageMock).toHaveBeenCalledTimes(1)
+    expect(getMessageMock).toHaveBeenCalledWith('hello')
+    expect(getMessageMock).not.toHaveBeenCalledWith('')
+  })
+})
+
+async function boot(): Promise<void> {
+  await import('./localize-html')
+}
+
+function mockChromeI18n(): void {
+  chromeMock.mockReturnValue({ i18n: { getMessage: getMessageMock } } as unknown as Chrome)
+}

--- a/src/components/Application/Application.test.tsx
+++ b/src/components/Application/Application.test.tsx
@@ -1,0 +1,89 @@
+import { flush } from 'solid-js'
+import { fireEvent, render, screen, waitFor, within } from '@solidjs/testing-library'
+import type { JSX } from '@solidjs/web'
+import createMediaQuery from '@/hooks/createMediaQuery'
+import useSettings from '@/hooks/useSettings'
+import { MilestoneProgressStyle, type Settings, ThemeColorMode } from '@/shared/settings'
+import Application from '.'
+
+vi.mock('@/hooks/useSettings')
+vi.mock('@/hooks/createMediaQuery')
+vi.mock('@/components/Layout', () => ({
+  default: (props: { children?: JSX.Element }) => <div data-testid="layout">{props.children}</div>,
+}))
+vi.mock('@/components/Time', () => ({
+  default: () => <div data-testid="time-stub">Time</div>,
+}))
+vi.mock('@/components/TimeMilestones', () => ({
+  default: () => <div data-testid="time-milestones-stub">TimeMilestones</div>,
+}))
+vi.mock('@/components/SettingsDialog', () => ({
+  default: () => (
+    <div role="dialog" aria-label="Settings">
+      Settings dialog stub
+    </div>
+  ),
+}))
+
+beforeEach(() => {
+  mockSettings()
+  vi.mocked(createMediaQuery).mockReturnValue(Object.assign(() => false, { query: false }))
+
+  const app = document.createElement('div')
+  app.id = 'app'
+  document.body.appendChild(app)
+})
+
+afterEach(() => {
+  document.getElementById('app')?.remove()
+  document.documentElement.removeAttribute('data-theme')
+  vi.resetAllMocks()
+})
+
+describe('Application', () => {
+  it('mounts the layout containing Time, TimeMilestones and the Footer', () => {
+    render(() => <Application />)
+
+    const layout = screen.getByTestId('layout')
+    expect(layout).toBeInTheDocument()
+
+    // Stubbed children live inside the Layout.
+    expect(within(layout).getByTestId('time-stub')).toBeInTheDocument()
+    expect(within(layout).getByTestId('time-milestones-stub')).toBeInTheDocument()
+
+    // The real Footer renders the settings button and the credits link.
+    expect(within(layout).getByTitle('Open settings')).toBeInTheDocument()
+    expect(within(layout).getByText('Made by khmm12')).toBeInTheDocument()
+  })
+
+  it('wires createApplyTheme so a theme is applied to <html>', () => {
+    render(() => <Application />)
+    flush()
+
+    // Auto + OS not-dark (mocked) resolves to light; the presence of the
+    // attribute proves Application invokes createApplyTheme.
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('opens the settings dialog when the Footer settings button is clicked', async () => {
+    render(() => <Application />)
+
+    // Dialog is absent until requested.
+    expect(screen.queryByText('Settings dialog stub')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTitle('Open settings'))
+    flush()
+
+    await waitFor(() => {
+      expect(screen.getByText('Settings dialog stub')).toBeInTheDocument()
+    })
+  })
+})
+
+function mockSettings(): void {
+  const settings: Settings = {
+    themeColorMode: ThemeColorMode.Auto,
+    milestoneProgressStyle: MilestoneProgressStyle.BarsCompact,
+  }
+  vi.mocked(useSettings).mockReturnValue([() => settings, vi.fn()])
+}

--- a/src/components/Application/hooks/createApplyTheme.test.ts
+++ b/src/components/Application/hooks/createApplyTheme.test.ts
@@ -1,4 +1,4 @@
-import { flush } from 'solid-js'
+import { createSignal, flush } from 'solid-js'
 import { renderHook } from '@solidjs/testing-library'
 import createMediaQuery from '@/hooks/createMediaQuery'
 import useSettings from '@/hooks/useSettings'
@@ -18,6 +18,18 @@ function mockSettings(themeColorMode: ThemeColorMode): void {
 
 function mockOSDark(isDark: boolean): void {
   vi.mocked(createMediaQuery).mockReturnValue(Object.assign(() => isDark, { query: isDark }))
+}
+
+/**
+ * Mocks `createMediaQuery` with a reactive, signal-backed accessor so tests can
+ * flip the OS dark-mode preference and drive the effects. Returns the setter.
+ */
+function mockReactiveOSDark(initial: boolean): (isDark: boolean) => void {
+  const [isOSDark, setIsOSDark] = createSignal(initial)
+  vi.mocked(createMediaQuery).mockReturnValue(Object.assign(() => isOSDark(), { query: initial }))
+  return (isDark) => {
+    setIsOSDark(isDark)
+  }
 }
 
 afterEach(() => {
@@ -73,6 +85,66 @@ describe('createApplyTheme', () => {
       flush()
 
       expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    })
+  })
+
+  describe('favicon refresh', () => {
+    let $favicon: HTMLLinkElement | undefined
+
+    function appendFavicon(): void {
+      const $el = document.createElement('link')
+      $el.rel = 'icon'
+      $el.type = 'image/svg+xml'
+      $el.href = '/favicon.svg'
+      document.head.append($el)
+      $favicon = $el
+    }
+
+    function faviconHasRefreshParam(): boolean {
+      if ($favicon == null) throw new Error('favicon link is not mounted')
+      return new URL($favicon.href).searchParams.has('t')
+    }
+
+    afterEach(() => {
+      $favicon?.remove()
+      $favicon = undefined
+    })
+
+    it('leaves the favicon href untouched on the initial run', () => {
+      mockSettings(ThemeColorMode.Auto)
+      mockReactiveOSDark(false)
+      appendFavicon()
+
+      renderHook(() => {
+        createApplyTheme()
+      })
+      flush()
+
+      // The effect is deferred, so the initial settle must not touch the href.
+      expect(faviconHasRefreshParam()).toBe(false)
+    })
+
+    it('toggles the cache-busting param on each OS dark-mode change', () => {
+      mockSettings(ThemeColorMode.Auto)
+      const setOSDark = mockReactiveOSDark(false)
+      appendFavicon()
+
+      renderHook(() => {
+        createApplyTheme()
+      })
+      flush()
+
+      expect(faviconHasRefreshParam()).toBe(false)
+
+      setOSDark(true)
+      flush()
+
+      expect(faviconHasRefreshParam()).toBe(true)
+
+      setOSDark(false)
+      flush()
+
+      expect(faviconHasRefreshParam()).toBe(false)
     })
   })
 })

--- a/src/components/Application/hooks/createMountEffect.test.ts
+++ b/src/components/Application/hooks/createMountEffect.test.ts
@@ -1,0 +1,136 @@
+import { flush } from 'solid-js'
+import { fireEvent, renderHook } from '@solidjs/testing-library'
+import type { MockInstance } from 'vitest'
+import createMountEffect from './createMountEffect'
+
+interface RafController {
+  raf: MockInstance<typeof window.requestAnimationFrame>
+  cancel: MockInstance<typeof window.cancelAnimationFrame>
+  flushFrame: () => void
+}
+
+let rafController: RafController
+
+function installRaf(): RafController {
+  let queue: Array<{ id: number; cb: FrameRequestCallback }> = []
+  let nextId = 0
+
+  const raf = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback): number => {
+    nextId += 1
+    queue.push({ id: nextId, cb })
+    return nextId
+  })
+
+  const cancel = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id: number): void => {
+    queue = queue.filter((entry) => entry.id !== id)
+  })
+
+  const flushFrame = (): void => {
+    const pending = queue
+    queue = []
+    for (const { cb } of pending) cb(performance.now())
+  }
+
+  return { raf, cancel, flushFrame }
+}
+
+function appendApp(): HTMLDivElement {
+  const $app = document.createElement('div')
+  $app.id = 'app'
+  document.body.appendChild($app)
+  return $app
+}
+
+beforeEach(() => {
+  rafController = installRaf()
+})
+
+afterEach(() => {
+  document.querySelector('#app')?.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('createMountEffect', () => {
+  it('fades in on the next frame and tears down on transitionend', () => {
+    const $app = appendApp()
+
+    renderHook(() => {
+      createMountEffect()
+    })
+    flush()
+
+    // A single frame is scheduled and nothing is applied before it runs.
+    expect(rafController.raf).toHaveBeenCalledTimes(1)
+    expect($app.style.opacity).toBe('')
+    expect($app.style.transition).toBe('')
+
+    rafController.flushFrame()
+
+    expect($app.style.opacity).toBe('1')
+    expect($app.style.transition).toBe('opacity 0.1s ease-out')
+
+    // transitionend triggers teardown, which clears the inline styles on the next frame.
+    fireEvent($app, new Event('transitionend'))
+    rafController.flushFrame()
+
+    expect($app.style.transition).toBe('')
+    expect($app.style.opacity).toBe('')
+  })
+
+  it('resets opacity without a transition when TransitionEvent is unavailable', () => {
+    vi.stubGlobal('TransitionEvent', undefined)
+    const $app = appendApp()
+    $app.style.opacity = '0'
+
+    renderHook(() => {
+      createMountEffect()
+    })
+    flush()
+
+    expect(rafController.raf).toHaveBeenCalledTimes(1)
+
+    rafController.flushFrame()
+
+    expect($app.style.opacity).toBe('')
+    expect($app.style.transition).toBe('')
+
+    // No transitionend listener is attached in the fallback path.
+    fireEvent($app, new Event('transitionend'))
+    expect(rafController.raf).toHaveBeenCalledTimes(1)
+  })
+
+  it('does nothing when there is no #app element', () => {
+    expect(() => {
+      renderHook(() => {
+        createMountEffect()
+      })
+      flush()
+    }).not.toThrow()
+
+    expect(rafController.raf).not.toHaveBeenCalled()
+  })
+
+  it('cancels the pending frame and detaches listeners on disposal', () => {
+    const $app = appendApp()
+
+    const { cleanup } = renderHook(() => {
+      createMountEffect()
+    })
+    flush()
+
+    expect(rafController.raf).toHaveBeenCalledTimes(1)
+
+    cleanup()
+
+    // The queued fade-in frame is cancelled exactly once during disposal.
+    expect(rafController.cancel).toHaveBeenCalledTimes(1)
+
+    // The start frame plus the teardown's cleanup frame have been requested.
+    expect(rafController.raf).toHaveBeenCalledTimes(2)
+
+    // Listeners were detached: a late transitionend no longer schedules any frame.
+    fireEvent($app, new Event('transitionend'))
+    expect(rafController.raf).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/components/Application/hooks/createSettingsDialog.test.tsx
+++ b/src/components/Application/hooks/createSettingsDialog.test.tsx
@@ -1,0 +1,139 @@
+import { setTimeout as tick } from 'node:timers/promises'
+import { flush, useContext } from 'solid-js'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import SettingsDialog from '@/components/SettingsDialog'
+import { ShowWithTransitionContext } from '@/components/ShowWithTransition'
+import useSettings from '@/hooks/useSettings'
+import { MilestoneProgressStyle, type Settings, ThemeColorMode } from '@/shared/settings'
+import createSettingsDialog from './createSettingsDialog'
+
+vi.mock('@/hooks/useSettings')
+vi.mock('@/components/SettingsDialog')
+
+const currentSettings: Settings = {
+  themeColorMode: ThemeColorMode.Auto,
+  milestoneProgressStyle: MilestoneProgressStyle.BarsCompact,
+}
+
+const savedSettings: Settings = {
+  themeColorMode: ThemeColorMode.Dark,
+  milestoneProgressStyle: MilestoneProgressStyle.BarsDetailed,
+}
+
+const setSettingsMock = vi.fn<(value: Settings) => Promise<void>>()
+
+beforeEach(() => {
+  setSettingsMock.mockResolvedValue(undefined)
+  vi.mocked(useSettings).mockReturnValue([() => currentSettings, setSettingsMock])
+  // Lightweight stub for the lazy dialog: exposes save/close triggers and
+  // mirrors the transition's `isOpened` so we can observe open/close state.
+  vi.mocked(SettingsDialog).mockImplementation((props) => {
+    const transition = useContext(ShowWithTransitionContext)
+    return (
+      <div
+        data-testid="settings-dialog-stub"
+        data-opened={transition.isOpened ? 'true' : 'false'}
+        data-theme={props.settings.themeColorMode}
+      >
+        <button
+          type="button"
+          onClick={() => {
+            void props.onSave?.(savedSettings)
+          }}
+        >
+          save
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            props.onClose?.()
+          }}
+        >
+          close
+        </button>
+      </div>
+    )
+  })
+})
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('createSettingsDialog', () => {
+  it('does not render the dialog until it is opened', async () => {
+    renderDialog()
+
+    // Give the lazy dialog a full macrotask to resolve — if it were shown by
+    // mistake, the stub would have mounted by now.
+    await tick(0)
+
+    expect(screen.queryByTestId('settings-dialog-stub')).not.toBeInTheDocument()
+    expect(SettingsDialog).not.toHaveBeenCalled()
+  })
+
+  it('renders the dialog after open()', async () => {
+    const { open } = renderDialog()
+
+    open()
+    flush()
+
+    const stub = await screen.findByTestId('settings-dialog-stub')
+    expect(stub).toBeInTheDocument()
+    expect(stub).toHaveAttribute('data-opened', 'true')
+    // The dialog receives the current settings from `useSettings`.
+    expect(stub).toHaveAttribute('data-theme', currentSettings.themeColorMode)
+  })
+
+  it('persists the settings before closing the dialog on save', async () => {
+    // Gate the write so we can observe that the close waits for the persist.
+    const persist = Promise.withResolvers<undefined>()
+    setSettingsMock.mockReturnValueOnce(persist.promise)
+
+    const { open } = renderDialog()
+
+    open()
+    flush()
+    const stub = await screen.findByTestId('settings-dialog-stub')
+    expect(stub).toHaveAttribute('data-opened', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'save' }))
+    flush()
+
+    // The write is issued immediately with the dialog's values...
+    expect(setSettingsMock).toHaveBeenCalledWith(savedSettings)
+    // ...but the dialog stays open until that write resolves (close awaits persist).
+    expect(stub).toHaveAttribute('data-opened', 'true')
+
+    persist.resolve(undefined)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-dialog-stub')).toHaveAttribute('data-opened', 'false')
+    })
+  })
+
+  it('closes the dialog on close without saving', async () => {
+    const { open } = renderDialog()
+
+    open()
+    flush()
+    const stub = await screen.findByTestId('settings-dialog-stub')
+    expect(stub).toHaveAttribute('data-opened', 'true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }))
+    flush()
+
+    expect(screen.getByTestId('settings-dialog-stub')).toHaveAttribute('data-opened', 'false')
+    expect(setSettingsMock).not.toHaveBeenCalled()
+  })
+})
+
+function renderDialog(): { open: () => void } {
+  let open: () => void = () => {}
+  render(() => {
+    const dialog = createSettingsDialog()
+    ;({ open } = dialog)
+    return dialog.$el
+  })
+  return { open }
+}

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,0 +1,54 @@
+import { render } from '@solidjs/testing-library'
+import { CloseIcon, SettingsIcon } from '.'
+
+describe('Icon', () => {
+  describe('SettingsIcon', () => {
+    it('renders correctly', () => {
+      const svg = querySvg(render(() => <SettingsIcon />).container)
+
+      expect(svg).toBeInTheDocument()
+      expect(svg).toMatchSnapshot()
+    })
+  })
+
+  describe('CloseIcon', () => {
+    it('renders correctly', () => {
+      const svg = querySvg(render(() => <CloseIcon />).container)
+
+      expect(svg).toBeInTheDocument()
+      expect(svg).toMatchSnapshot()
+    })
+  })
+
+  describe('iconProps', () => {
+    it('merges a custom class with the generated icon style class', () => {
+      const baseTokens = classTokens(querySvg(render(() => <SettingsIcon />).container))
+      expect(baseTokens.length).toBeGreaterThan(0)
+
+      const svg = querySvg(render(() => <SettingsIcon class="my-class" />).container)
+
+      expect(svg).toHaveClass(...baseTokens, 'my-class')
+      expect(classTokens(svg)).toContain('my-class')
+    })
+
+    it('merges the css prop into the generated class', () => {
+      const baseTokens = classTokens(querySvg(render(() => <SettingsIcon />).container))
+
+      const svg = querySvg(render(() => <SettingsIcon css={{ color: 'red' }} />).container)
+
+      expect(svg).toHaveClass(...baseTokens)
+      expect(classTokens(svg).length).toBeGreaterThan(baseTokens.length)
+    })
+  })
+})
+
+function querySvg(container: HTMLElement): SVGSVGElement {
+  const svg = container.querySelector('svg')
+  if (svg == null) throw new Error('Expected an <svg> element to be rendered')
+  return svg
+}
+
+function classTokens(el: Element): string[] {
+  const value = el.getAttribute('class') ?? ''
+  return value.split(/\s+/).filter((token) => token.length > 0)
+}

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -1,0 +1,39 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Icon > CloseIcon > renders correctly 1`] = `
+<svg
+  class="w_1em h_1em"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path
+    d="M24 2.417 21.583 0 12 9.583 2.417 0 0 2.417 9.583 12 0 21.583 2.417 24 12 14.417 21.583 24 24 21.583 14.417 12z"
+    fill="currentColor"
+    fill-rule="nonzero"
+  />
+</svg>
+`;
+
+exports[`Icon > SettingsIcon > renders correctly 1`] = `
+<svg
+  class="w_1em h_1em"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <g
+    fill="none"
+    fill-rule="evenodd"
+    stroke="currentColor"
+    stroke-width="1.161"
+  >
+    <path
+      d="M15.45.658c.743.226 1.456.523 2.13.883l-.262 5.141 5.141-.262c.36.674.657 1.386.883 2.13L19.521 12l3.821 3.45a11.775 11.775 0 0 1-.884 2.13l-5.14-.262.262 5.14c-.674.36-1.386.658-2.13.884L12 19.52l-3.45 3.822a11.775 11.775 0 0 1-2.13-.883l.262-5.141-5.14.263a11.775 11.775 0 0 1-.884-2.131L4.48 12 .658 8.55c.226-.744.523-1.456.883-2.13l5.141.262-.262-5.14C7.094 1.18 7.807.883 8.551.657l3.45 3.822Z"
+    />
+    <circle
+      cx="11.963"
+      cy="11.963"
+      r="4.065"
+    />
+  </g>
+</svg>
+`;

--- a/src/components/SettingsButton/SettingsButton.test.tsx
+++ b/src/components/SettingsButton/SettingsButton.test.tsx
@@ -1,6 +1,16 @@
 import { createMemo, createSignal, flush, Loading, Show } from 'solid-js'
 import { fireEvent, render, waitFor } from '@solidjs/testing-library'
+import * as dom from '@/utils/dom'
 import SettingsButton from '.'
+
+vi.mock('@/utils/dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof dom>()),
+  supportsAnimations: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
 
 describe('SettingsButton', () => {
   it('renders a button', async () => {
@@ -93,5 +103,120 @@ describe('SettingsButton', () => {
     expect(button).toHaveAttribute('aria-busy', 'true')
 
     p.resolve(null)
+  })
+})
+
+describe('SettingsButton icon animation', () => {
+  it('activates the icon while opening and stops once the iteration finishes', async () => {
+    vi.mocked(dom.supportsAnimations).mockReturnValue(true)
+
+    const p = Promise.withResolvers<null>()
+
+    const r = render(() => {
+      const [isShown, setIsShown] = createSignal(false)
+      const deferred = createMemo(async () => await p.promise, { lazy: true })
+
+      return (
+        <>
+          <SettingsButton
+            onClick={() => {
+              setIsShown(true)
+            }}
+          />
+          <Show when={isShown()}>
+            <Loading>{deferred()}</Loading>
+          </Show>
+        </>
+      )
+    })
+
+    const button = r.getByRole('button')
+    const svg = button.querySelector('svg')
+    if (svg == null) throw new Error('settings icon svg is not mounted')
+
+    // Idle: nothing is animating yet.
+    expect(svg).not.toHaveAttribute('data-active')
+
+    fireEvent.click(button)
+    flush()
+
+    // Loading started and animations are supported -> the icon is marked active.
+    expect(svg).toHaveAttribute('data-active', 'true')
+
+    p.resolve(null)
+
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-disabled', 'false')
+    })
+
+    // Loading finished, but the animation keeps running until the current iteration ends.
+    expect(svg).toHaveAttribute('data-active', 'true')
+
+    // Iteration finishes while no longer loading -> the animation stops and the flag is removed.
+    fireEvent(svg, new Event('animationiteration'))
+    flush()
+
+    expect(svg).not.toHaveAttribute('data-active')
+  })
+
+  it('keeps running across iterations while still loading', async () => {
+    vi.mocked(dom.supportsAnimations).mockReturnValue(true)
+
+    const p = Promise.withResolvers<null>()
+
+    const r = render(() => {
+      const [isShown, setIsShown] = createSignal(false)
+      const deferred = createMemo(async () => await p.promise, { lazy: true })
+
+      return (
+        <>
+          <SettingsButton
+            onClick={() => {
+              setIsShown(true)
+            }}
+          />
+          <Show when={isShown()}>
+            <Loading>{deferred()}</Loading>
+          </Show>
+        </>
+      )
+    })
+
+    const button = r.getByRole('button')
+    const svg = button.querySelector('svg')
+    if (svg == null) throw new Error('settings icon svg is not mounted')
+
+    fireEvent.click(button)
+    flush()
+
+    expect(svg).toHaveAttribute('data-active', 'true')
+
+    // An iteration ends but loading is still pending -> the icon stays active.
+    fireEvent(svg, new Event('animationiteration'))
+    flush()
+
+    expect(svg).toHaveAttribute('data-active', 'true')
+
+    p.resolve(null)
+
+    await waitFor(() => {
+      expect(button).toHaveAttribute('aria-disabled', 'false')
+    })
+  })
+
+  it('does not activate the icon when animations are unsupported', () => {
+    vi.mocked(dom.supportsAnimations).mockReturnValue(false)
+
+    const handleClick = vi.fn()
+    const r = render(() => <SettingsButton onClick={handleClick} />)
+
+    const button = r.getByRole('button')
+    const svg = button.querySelector('svg')
+    if (svg == null) throw new Error('settings icon svg is not mounted')
+
+    fireEvent.click(button)
+    flush()
+
+    expect(svg).not.toHaveAttribute('data-active')
   })
 })

--- a/src/components/SettingsDialog/components/SettingsForm/SettingsForm.test.tsx
+++ b/src/components/SettingsDialog/components/SettingsForm/SettingsForm.test.tsx
@@ -1,0 +1,185 @@
+import { createSignal, flush } from 'solid-js'
+import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library'
+import { MilestoneProgressStyle, type Settings, ThemeColorMode } from '@/shared/settings'
+import toISODate from '@/utils/to-iso-date'
+import SettingsForm from '.'
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('SettingsForm', () => {
+  it('submits with the newly selected theme color mode', async () => {
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={defaults()} onSubmit={onSubmit} />)
+
+    const select = screen.getByLabelText('Theme color mode')
+    fireEvent.change(select, { target: { value: ThemeColorMode.Dark } })
+    flush()
+
+    expect(select).toHaveValue(ThemeColorMode.Dark)
+
+    fireEvent.submit(screen.getByRole('form'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ themeColorMode: ThemeColorMode.Dark }))
+    })
+  })
+
+  it('submits with the newly selected milestone progress style', async () => {
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={defaults()} onSubmit={onSubmit} />)
+
+    const select = screen.getByLabelText('Milestone progress style')
+    fireEvent.change(select, { target: { value: MilestoneProgressStyle.BarsDetailed } })
+    flush()
+
+    expect(select).toHaveValue(MilestoneProgressStyle.BarsDetailed)
+
+    fireEvent.submit(screen.getByRole('form'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ milestoneProgressStyle: MilestoneProgressStyle.BarsDetailed }),
+      )
+    })
+  })
+
+  it('includes the entered birth date in the submitted settings', async () => {
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={defaults()} onSubmit={onSubmit} />)
+
+    const input = screen.getByLabelText('Birth date')
+    const inputValue = '1990-05-15'
+    fireEvent.change(input, { target: { value: inputValue } })
+    flush()
+
+    expect(input).toHaveValue(inputValue)
+
+    fireEvent.submit(screen.getByRole('form'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ birthDate: toISODate(new Date(inputValue)) }))
+    })
+  })
+
+  it('omits birth date from the submitted settings when cleared', async () => {
+    const birthDate = toISODate(new Date(1990, 4, 15))
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={defaults({ birthDate })} onSubmit={onSubmit} />)
+
+    const input = screen.getByLabelText('Birth date')
+    expect(input).toHaveValue(birthDate)
+
+    fireEvent.change(input, { target: { value: '' } })
+    flush()
+
+    expect(input).toHaveValue('')
+
+    fireEvent.submit(screen.getByRole('form'))
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          themeColorMode: ThemeColorMode.Auto,
+          milestoneProgressStyle: MilestoneProgressStyle.BarsCompact,
+        }),
+      )
+    })
+    expect(onSubmit.mock.lastCall?.[0]).not.toHaveProperty('birthDate')
+  })
+
+  it('shows the saving label while the submit is pending and restores it afterwards', async () => {
+    const pending = Promise.withResolvers<null>()
+    const onSubmit = vi.fn(async () => {
+      await pending.promise
+    })
+    render(() => <SettingsForm initialValues={defaults()} onSubmit={onSubmit} />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveTextContent(/^Save$/)
+    expect(button).not.toBeDisabled()
+
+    fireEvent.submit(screen.getByRole('form'))
+    flush()
+
+    expect(button).toHaveTextContent(/^Saving$/)
+    expect(button).toBeDisabled()
+
+    pending.resolve(null)
+
+    await waitFor(() => {
+      expect(button).toHaveTextContent(/^Save$/)
+      expect(button).not.toBeDisabled()
+    })
+  })
+
+  it('keeps the form dirty while a save is in flight', () => {
+    // The form only clears `isDirty` after the awaited save resolves. Until then it must stay
+    // dirty so a failed/pending save is retriable and an external initialValues change can't
+    // clobber the user's edit.
+    const pending = Promise.withResolvers<null>()
+    const onSubmit = vi.fn(async () => {
+      await pending.promise
+    })
+    const [initialValues, setInitialValues] = createSignal(defaults())
+    render(() => <SettingsForm initialValues={initialValues()} onSubmit={onSubmit} />)
+
+    const themeSelect = screen.getByLabelText('Theme color mode')
+    fireEvent.change(themeSelect, { target: { value: ThemeColorMode.Light } })
+    flush()
+
+    fireEvent.submit(screen.getByRole('form'))
+    flush()
+
+    setInitialValues(defaults({ themeColorMode: ThemeColorMode.Dark }))
+    flush()
+
+    expect(themeSelect).toHaveValue(ThemeColorMode.Light)
+  })
+
+  it('re-syncs fields when initialValues change and the form is not dirty', () => {
+    const [initialValues, setInitialValues] = createSignal(defaults())
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={initialValues()} onSubmit={onSubmit} />)
+
+    expect(screen.getByLabelText('Theme color mode')).toHaveValue(ThemeColorMode.Auto)
+    expect(screen.getByLabelText('Milestone progress style')).toHaveValue(MilestoneProgressStyle.BarsCompact)
+
+    setInitialValues(
+      defaults({
+        themeColorMode: ThemeColorMode.Dark,
+        milestoneProgressStyle: MilestoneProgressStyle.BarsDetailed,
+      }),
+    )
+    flush()
+
+    expect(screen.getByLabelText('Theme color mode')).toHaveValue(ThemeColorMode.Dark)
+    expect(screen.getByLabelText('Milestone progress style')).toHaveValue(MilestoneProgressStyle.BarsDetailed)
+  })
+
+  it('keeps user edits when initialValues change after the form became dirty', () => {
+    const [initialValues, setInitialValues] = createSignal(defaults())
+    const onSubmit = vi.fn<(values: Settings) => void>()
+    render(() => <SettingsForm initialValues={initialValues()} onSubmit={onSubmit} />)
+
+    const themeSelect = screen.getByLabelText('Theme color mode')
+    fireEvent.change(themeSelect, { target: { value: ThemeColorMode.Light } })
+    flush()
+
+    expect(themeSelect).toHaveValue(ThemeColorMode.Light)
+
+    setInitialValues(defaults({ themeColorMode: ThemeColorMode.Dark }))
+    flush()
+
+    expect(themeSelect).toHaveValue(ThemeColorMode.Light)
+  })
+})
+
+function defaults(opts?: Partial<Settings>): Settings {
+  return {
+    milestoneProgressStyle: MilestoneProgressStyle.BarsCompact,
+    themeColorMode: ThemeColorMode.Auto,
+    ...opts,
+  }
+}

--- a/src/components/TimeMilestones/components/Milestone/components/Progress/Progress.test.tsx
+++ b/src/components/TimeMilestones/components/Milestone/components/Progress/Progress.test.tsx
@@ -1,0 +1,122 @@
+import { render } from '@solidjs/testing-library'
+import Progress, { ProgressVariant } from '.'
+
+describe('Progress', () => {
+  describe('variant Bars', () => {
+    it('renders one path per bar with clamped per-bar fill geometry', () => {
+      const { container } = render(() => (
+        <Progress variant={ProgressVariant.Bars} barsNumber={10} barWidth={1.2} width={25} progress={0.25} />
+      ))
+
+      const paths = Array.from(container.querySelectorAll('path'))
+      expect(paths).toHaveLength(10)
+
+      const ds = paths.map((p) => p.getAttribute('d'))
+      // progress * barsNumber = 2.5 -> bars 0 and 1 are fully lit (lineProgress clamped to 1), y = 0 (top).
+      expect(ds[0]).toBe('M0.6 0 L0.6 5 Z')
+      expect(ds[1]).toBe('M3.2444444444 0 L3.2444444444 5 Z')
+      // bar 2 is partially lit (lineProgress = 0.5), barHeight = 2.625 -> y = 2.375.
+      expect(ds[2]).toBe('M5.8888888889 2.375 L5.8888888889 5 Z')
+      // bars >= 3 are unlit (lineProgress clamped to 0) and sit at minHeight (0.25) -> y = 4.75.
+      expect(ds[3]).toBe('M8.5333333333 4.75 L8.5333333333 5 Z')
+      expect(ds[9]).toBe('M24.4 4.75 L24.4 5 Z')
+
+      // every bar carries the configured bar width as its stroke width.
+      expect(paths.map((p) => p.getAttribute('stroke-width'))).toEqual(Array.from({ length: 10 }, () => '1.2'))
+
+      // a fully-lit bar (index 0) is taller (smaller y) than an unlit bar (index 4).
+      expect(barY(paths[0])).toBeLessThan(barY(paths[4]))
+    })
+
+    it('keeps every bar at minHeight when progress is 0 (lower clamp)', () => {
+      const { container } = render(() => (
+        <Progress variant={ProgressVariant.Bars} barsNumber={10} barWidth={1.2} width={25} progress={0} />
+      ))
+
+      const paths = Array.from(container.querySelectorAll('path'))
+      expect(paths).toHaveLength(10)
+      // progress * barsNumber - index <= 0 for all bars -> Math.max floors lineProgress at 0.
+      expect(paths.map((p) => barY(p))).toEqual(Array.from({ length: 10 }, () => 4.75))
+    })
+
+    it('fills every bar fully when progress is 1 (upper clamp)', () => {
+      const { container } = render(() => (
+        <Progress variant={ProgressVariant.Bars} barsNumber={10} barWidth={1.2} width={25} progress={1} />
+      ))
+
+      const paths = Array.from(container.querySelectorAll('path'))
+      expect(paths).toHaveLength(10)
+      // progress * barsNumber - index >= 1 for all bars -> Math.min caps lineProgress at 1, y = 0.
+      expect(paths.map((p) => barY(p))).toEqual(Array.from({ length: 10 }, () => 0))
+    })
+
+    it('clamps bar height at full when progress exceeds 1', () => {
+      const { container } = render(() => (
+        <Progress variant={ProgressVariant.Bars} barsNumber={10} barWidth={1.2} width={25} progress={1.5} />
+      ))
+
+      const paths = Array.from(container.querySelectorAll('path'))
+      // lineProgress would exceed 1 for every bar; Math.min still caps it at 1, y stays 0.
+      expect(paths.map((p) => barY(p))).toEqual(Array.from({ length: 10 }, () => 0))
+    })
+  })
+
+  describe('variant HorizontalBar', () => {
+    it('renders a full-width background and a progress rect sized to progress', () => {
+      const { container } = render(() => <Progress variant={ProgressVariant.HorizontalBar} width={30} progress={0.5} />)
+
+      const rects = Array.from(container.querySelectorAll('rect'))
+      expect(rects).toHaveLength(2)
+
+      const [background, fill] = rects
+      // background spans the full width at minHeight.
+      expect(background?.getAttribute('x')).toBe('0')
+      expect(background?.getAttribute('y')).toBe('4.75')
+      expect(background?.getAttribute('width')).toBe('30')
+      expect(background?.getAttribute('height')).toBe('0.25')
+      // fill width === round(progress * width) === 15, full height, anchored at the top.
+      expect(fill?.getAttribute('x')).toBe('0')
+      expect(fill?.getAttribute('y')).toBe('0')
+      expect(fill?.getAttribute('width')).toBe('15')
+      expect(fill?.getAttribute('height')).toBe('5')
+    })
+
+    it('renders an empty progress rect when progress is 0', () => {
+      const { container } = render(() => <Progress variant={ProgressVariant.HorizontalBar} width={30} progress={0} />)
+
+      const rects = Array.from(container.querySelectorAll('rect'))
+      expect(rects[0]?.getAttribute('width')).toBe('30')
+      expect(rects[1]?.getAttribute('width')).toBe('0')
+    })
+
+    it('renders a full-width progress rect when progress is 1', () => {
+      const { container } = render(() => <Progress variant={ProgressVariant.HorizontalBar} width={30} progress={1} />)
+
+      const rects = Array.from(container.querySelectorAll('rect'))
+      expect(rects[0]?.getAttribute('width')).toBe('30')
+      expect(rects[1]?.getAttribute('width')).toBe('30')
+    })
+  })
+
+  describe('default props', () => {
+    it('merges default width and height into the viewBox', () => {
+      const { container } = render(() => (
+        <Progress variant={ProgressVariant.Bars} barsNumber={5} barWidth={1} progress={0.5} />
+      ))
+
+      // width/height/minHeight omitted -> defaults 25 / 5 / 0.25 applied by merge().
+      expect(container.querySelector('svg')?.getAttribute('viewBox')).toBe('0 0 25 5')
+
+      const paths = Array.from(container.querySelectorAll('path'))
+      // the trailing unlit bar sits at default height - default minHeight = 5 - 0.25 = 4.75.
+      expect(barY(paths[paths.length - 1])).toBe(4.75)
+    })
+  })
+})
+
+// The bar `d` attribute has the shape `M{x} {y} L{x} {height} Z`; the second
+// token is the top y-coordinate (smaller y == taller, more-filled bar).
+function barY(path: Element | undefined): number {
+  const d = path?.getAttribute('d') ?? ''
+  return Number(d.split(' ')[1])
+}

--- a/src/components/TimeMilestones/utils.test.ts
+++ b/src/components/TimeMilestones/utils.test.ts
@@ -77,6 +77,22 @@ describe('getYearMilestone', () => {
   })
 })
 
+describe('getDayMilestone across a DST transition', () => {
+  afterAll(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('caps the milestone at 1 during the extra DST hour', () => {
+    // "Fall back" day: the local day is 25h long, longer than the constant 86400s divisor.
+    // On 2021-11-07 New York fell back at 02:00; by 23:30 local, 24.5h have elapsed since
+    // local midnight, so the uncapped fraction would be ~1.0208.
+    vi.stubEnv('TZ', 'America/New_York')
+    const currentDateTime = new Date('2021-11-07T23:30:00')
+
+    expect(getDayMilestone(currentDateTime)).toBe(1)
+  })
+})
+
 describe('getBirthDayMilestone', () => {
   it('handles not appeared birth date in this year', () => {
     const currentDateTime = new Date('2022-04-01')

--- a/src/components/TimeMilestones/utils.ts
+++ b/src/components/TimeMilestones/utils.ts
@@ -65,8 +65,10 @@ function getLastYearDate(date: Date): CalculateRelative<Date> {
 function milestone(getSecondsInEpoch: GetSecondsInEpoch, getStartOfEpoch: GetStartOfEpoch): GetMilestone {
   return (now) => {
     const secondsSinceStart = differenceInSeconds(now, getStartOfEpoch(now))
+    // On a DST "fall back" day the local epoch runs longer than the constant divisor
+    // (a 25h day vs 86400s), so the raw fraction can creep past 1 — cap it.
     const value = secondsSinceStart / getSecondsInEpoch(now)
-    return roundDown(value, PRECISION)
+    return roundDown(Math.min(value, 1), PRECISION)
   }
 }
 

--- a/src/hooks/createPolled.test.ts
+++ b/src/hooks/createPolled.test.ts
@@ -1,0 +1,117 @@
+import { flush } from 'solid-js'
+import { renderHook } from '@solidjs/testing-library'
+import createPolled, { type PolledStrategy } from './createPolled'
+
+const DELAY = 1000
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.resetAllMocks()
+})
+
+describe('createPolled', () => {
+  it('never ticks when disabled', () => {
+    vi.setSystemTime(0)
+    const onTick = vi.fn<() => void>()
+
+    renderHook(() => {
+      createPolled({ enabled: false, every: fixedDelayStrategy(DELAY), onTick })
+    })
+    flush()
+
+    vi.advanceTimersByTime(DELAY * 5)
+
+    expect(onTick).not.toHaveBeenCalled()
+  })
+
+  it('ticks after the delay and reschedules itself', () => {
+    vi.setSystemTime(0)
+    const onTick = vi.fn<() => void>()
+
+    renderHook(() => {
+      createPolled({ enabled: true, every: fixedDelayStrategy(DELAY), onTick })
+    })
+    flush()
+
+    expect(onTick).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(DELAY)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(DELAY)
+
+    expect(onTick).toHaveBeenCalledTimes(2)
+  })
+
+  it('ticks immediately via a microtask when the scheduled time is not in the future', async () => {
+    const onTick = vi.fn<() => void>()
+
+    renderHook(() => {
+      createPolled({ enabled: true, every: immediateThenIdleStrategy(), onTick })
+    })
+    flush()
+
+    // Immediate schedules through queueMicrotask, not synchronously.
+    expect(onTick).not.toHaveBeenCalled()
+
+    await Promise.resolve()
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops ticking after disposal', () => {
+    vi.setSystemTime(0)
+    const onTick = vi.fn<() => void>()
+
+    const { cleanup } = renderHook(() => {
+      createPolled({ enabled: true, every: fixedDelayStrategy(DELAY), onTick })
+    })
+    flush()
+
+    vi.advanceTimersByTime(DELAY)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+
+    // A follow-up tick is already scheduled via setTimeout; disposal must clear it.
+    cleanup()
+
+    vi.advanceTimersByTime(DELAY * 5)
+
+    expect(onTick).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Deterministic strategy: schedules `delay` ms in the future relative to the
+// last tick, with now() tracking the (fake) clock. Advancing fake timers by
+// `delay` reaches the scheduled time exactly.
+function fixedDelayStrategy(delay: number): PolledStrategy {
+  return {
+    now: (): number => Date.now(),
+    scheduledAt: (relative: number): number => relative + delay,
+  }
+}
+
+// Deterministic strategy: first schedule resolves to `delay <= 0` (immediate,
+// queued via microtask), every later schedule resolves far in the future so the
+// self-reschedule lands on a setTimeout that never fires (timers are not
+// advanced). This exercises the immediate branch exactly once, without an
+// unbounded microtask loop.
+function immediateThenIdleStrategy(): PolledStrategy {
+  const at = 1000
+  let firstSchedule = true
+  return {
+    now: (): number => at,
+    scheduledAt: (): number => {
+      if (firstSchedule) {
+        firstSchedule = false
+        return at // delay = at - now() = 0 -> queueMicrotask(tick)
+      }
+      return at + 60_000 // delay > 0 -> setTimeout(tick), never advanced
+    },
+  }
+}

--- a/src/shared/settings.test.ts
+++ b/src/shared/settings.test.ts
@@ -1,5 +1,11 @@
 import toISODate from '@/utils/to-iso-date'
-import { MilestoneProgressStyle, type Settings, settingsSerializer, ThemeColorMode } from './settings'
+import {
+  buildSettingsStorage,
+  MilestoneProgressStyle,
+  type Settings,
+  settingsSerializer,
+  ThemeColorMode,
+} from './settings'
 
 describe('settings', () => {
   describe('settingsSerializer', () => {
@@ -55,6 +61,32 @@ describe('settings', () => {
         themeColorMode: ThemeColorMode.Auto,
         milestoneProgressStyle: MilestoneProgressStyle.BarsCompact,
       })
+    })
+  })
+
+  describe('buildSettingsStorage', () => {
+    afterEach(() => {
+      localStorage.clear()
+    })
+
+    it('round-trips settings through the backend using the settings serializer', async () => {
+      // Exercises the wiring of line 59 end-to-end: `write` runs
+      // `settingsSerializer.serialize` into the backend, `read` runs
+      // `deserialize` back out. In the test env `buildStorageAdapter` resolves
+      // to the localStorage adapter (no `chrome` global).
+      const storage = buildSettingsStorage()
+      const settings: Settings = {
+        birthDate: toISODate(new Date()),
+        themeColorMode: ThemeColorMode.Dark,
+        milestoneProgressStyle: MilestoneProgressStyle.HorizontalBar,
+      }
+
+      await storage.write(settings)
+      const read = await storage.read()
+
+      expect(read).toEqual(settings)
+
+      storage.dispose()
     })
   })
 })

--- a/src/utils/storage/utils.test.ts
+++ b/src/utils/storage/utils.test.ts
@@ -1,0 +1,46 @@
+import chrome from '@/utils/chrome'
+import ChromeStorageAdapter from './adapters/chrome-storage-adapter'
+import LocalStorageAdapter from './adapters/local-storage-adapter'
+import MemoryStorageAdapter from './adapters/memory-storage-adapter'
+import { buildStorageAdapter } from './utils'
+
+vi.mock('@/utils/chrome')
+
+afterEach(() => {
+  vi.resetAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('buildStorageAdapter', () => {
+  it('builds a ChromeStorageAdapter when the chrome storage API is available', async () => {
+    // The adapter's constructor subscribes to the real global `chrome`, so it
+    // must exist too — the mocked `chrome()` only drives branch selection.
+    vi.stubGlobal('chrome', {
+      storage: {
+        onChanged: { addListener: vi.fn(), removeListener: vi.fn() },
+      },
+    })
+    vi.mocked(chrome).mockReturnValue(globalThis.chrome)
+
+    const adapter = await buildStorageAdapter('test')
+
+    expect(adapter).toBeInstanceOf(ChromeStorageAdapter)
+  })
+
+  it('builds a LocalStorageAdapter when chrome is absent but localStorage exists', async () => {
+    vi.mocked(chrome).mockReturnValue(undefined)
+
+    const adapter = await buildStorageAdapter('test')
+
+    expect(adapter).toBeInstanceOf(LocalStorageAdapter)
+  })
+
+  it('builds a MemoryStorageAdapter when neither chrome nor localStorage is available', async () => {
+    vi.mocked(chrome).mockReturnValue(undefined)
+    vi.stubGlobal('localStorage', undefined)
+
+    const adapter = await buildStorageAdapter('test')
+
+    expect(adapter).toBeInstanceOf(MemoryStorageAdapter)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,10 @@
 import { fileURLToPath } from 'node:url'
 import browserslistToEsbuild from 'browserslist-to-esbuild'
 import { defineConfig } from 'vite'
-import 'vitest/config'
 import { createHtmlPlugin } from 'vite-plugin-html'
 import solidPlugin from 'vite-plugin-solid'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { coverageConfigDefaults } from 'vitest/config'
 import manifestPlugin from './lib/vite/manifest-plugin.js'
 
 export default defineConfig(() => ({
@@ -48,6 +48,9 @@ export default defineConfig(() => ({
     environment: 'happy-dom',
     coverage: {
       include: ['src'],
+      // Non-code assets (manifest, locale JSON, fonts, icons, styles) are not
+      // executable — drop them so they don't skew the coverage denominator.
+      exclude: [...coverageConfigDefaults.exclude, '**/*.json', '**/*.css', '**/*.svg', '**/*.woff2'],
     },
   },
 }))


### PR DESCRIPTION
## Summary

Expand unit-test coverage across previously untested modules, and fix a small DST edge case surfaced while reviewing the new tests.

**Coverage: ~85% → ~99% lines** (statements 84% → 97%, branches 74% → 87%, functions 83% → 93%). +51 tests (170 → 221).

### Tests added / extended
- **New (were 0%):** `storage/utils` (adapter selection), `boot/localize-html` (import-time localization), `Application` (wiring smoke), `createMountEffect`, `createSettingsDialog`, `Icon` (snapshot + class merge), `createPolled`, `Progress` (real geometry assertions, not just snapshots).
- **Extended:** `createApplyTheme` (favicon refresh on OS theme change), `SettingsButton` (icon animation branch), `settings` (storage round-trip), `SettingsForm` (select/date handlers, dirty-state, in-flight save).

### DST fix
`milestone()` divided elapsed wall-clock seconds by a **constant** epoch length (86400s/day, etc.). On a DST "fall back" day the local day runs 25h, so the fraction could creep past 1 — showing as e.g. "104% of day" and a horizontal progress bar overflowing its track. Clamped at the source (`Math.min(value, 1)`) so all consumers see the `[0,1]` invariant; covered by a deterministic test that pins the timezone via `vi.stubEnv`.

### Tooling
`vite.config.ts`: exclude non-code assets (json/css/svg/woff2) from the coverage denominator so the metric reflects executable source only.

## Testing
- `pnpm test:unit` — 221/221 pass
- `pnpm lint` — clean
- `pnpm typecheck` (app + node) — clean

No production behavior changes beyond the DST clamp; no visual changes to screenshot.
