### PR TITLE
style(settings): redesign settings modal and dark-theme adaptation

### DIFF
--- a/src/components/Modal/styles.ts
+++ b/src/components/Modal/styles.ts
@@ -32,10 +32,13 @@ export const overlay = css.raw({
 })
 
 export const dialog = css.raw({
-  flex: '0 1 30rem',
+  flex: '0 1 28rem',
   background: { base: 'white', _dark: 'neutral.700' },
-  borderRadius: '0.25rem',
-  boxShadow: { base: '0 0 0.5rem 0 {colors.black/48}', _dark: '0 0 0.5rem 0 {colors.black/60}' },
+  borderRadius: '0.75rem',
+  boxShadow: {
+    base: '0 0.625rem 0.9375rem -0.1875rem {colors.black/15}, 0 0.25rem 0.375rem -0.25rem {colors.black/20}',
+    _dark: '0 0.625rem 1.5625rem -0.3125rem {colors.black/50}, 0 0.5rem 0.625rem -0.375rem {colors.black/40}',
+  },
   color: { base: 'black', _dark: 'white' },
   display: 'flex',
   flexDirection: 'column',
@@ -105,7 +108,7 @@ export const closeButtonIcon = css.raw({
 
 export const body = css.raw({
   width: 'full',
-  padding: '1rem 1.5rem',
+  padding: '1.5rem',
   display: 'flex',
   flexDirection: 'column',
 })

--- a/src/components/SettingsDialog/components/SettingsForm/styles.ts
+++ b/src/components/SettingsDialog/components/SettingsForm/styles.ts
@@ -2,41 +2,55 @@ import { css } from 'styled-system/css'
 import * as p from 'styled-system/patterns'
 
 export const container = p.vstack.raw({
-  gap: '1rem',
+  gap: '1.25rem',
 })
 
 export const formGroup = p.vstack.raw({
   width: 'full',
-  gap: 0,
+  gap: '0.375rem',
   alignItems: 'stretch',
 })
 
 export const label = css.raw({
-  fontSize: '0.875rem',
-  margin: '0 0 0.5rem',
+  fontSize: '0.8125rem',
+  fontWeight: 500,
+  letterSpacing: '0.01em',
+  color: { base: 'neutral.600', _dark: 'neutral.300' },
 })
 
 export const input = css.raw({
   fontFamily: 'inherit',
-  fontSize: '1rem',
-  padding: '0.5rem 0.75rem',
-  height: '2.5rem',
-  color: { base: 'black', _dark: 'white' },
-  bgColor: { base: 'white', _dark: 'neutral.700' },
+  fontSize: '0.9375rem',
+  lineHeight: 1.2,
+  padding: '0 0.75rem',
+  height: '2.75rem',
+  width: 'full',
+  color: { base: 'neutral.900', _dark: 'neutral.100' },
+  bgColor: { base: 'white', _dark: 'neutral.800' },
   border: '1px solid',
-  borderColor: { base: 'black', _dark: 'white' },
-  borderRadius: '0.25rem',
+  borderColor: { base: 'neutral.300', _dark: 'neutral.600' },
+  borderRadius: '0.5rem',
   colorScheme: { base: 'light', _dark: 'dark' },
+  outline: 'none',
+  transition: 'border-color 0.15s ease, box-shadow 0.15s ease',
+  _hover: {
+    borderColor: { base: 'neutral.400', _dark: 'neutral.500' },
+  },
+  _focusVisible: {
+    borderColor: { base: 'neutral.900', _dark: 'neutral.100' },
+    boxShadow: { base: '0 0 0 0.1875rem {colors.neutral.900/12}', _dark: '0 0 0 0.1875rem {colors.neutral.100/18}' },
+  },
 })
 
 export const select = css.raw({
   ...input,
   appearance: 'none',
+  cursor: 'pointer',
   bgRepeat: 'no-repeat',
-  bgPosition: 'right 0.375rem center',
+  bgPosition: 'right 0.5rem center',
   bgImage: { base: 'var(--img-b)', _dark: 'var(--img-w)' },
   bgSize: '1.5rem 1.5rem',
-  paddingRight: '2.25rem',
+  paddingRight: '2.5rem',
 })
 
 // Runtime
@@ -47,13 +61,31 @@ export const selectInline = {
 
 export const button = css.raw({
   appearance: 'none',
-  background: { base: 'none', _hover: { base: 'black/10', _dark: 'white/10' } },
-  borderRadius: '0.25rem',
-  border: '1px solid',
-  borderColor: { base: 'black', _dark: 'white' },
-  color: { base: 'black', _dark: 'white' },
+  width: 'full',
+  height: '2.75rem',
+  marginTop: '0.25rem',
+  borderRadius: '0.5rem',
+  border: 'none',
   cursor: 'pointer',
-  fontSize: '1rem',
-  margin: '0.5rem 0 0',
-  padding: '0.5rem 1.5rem',
+  fontFamily: 'inherit',
+  fontSize: '0.9375rem',
+  fontWeight: 500,
+  letterSpacing: '0.01em',
+  color: { base: 'white', _dark: 'neutral.900' },
+  bgColor: { base: 'neutral.900', _dark: 'neutral.100' },
+  outline: 'none',
+  transition: 'background-color 0.15s ease, box-shadow 0.15s ease, opacity 0.15s ease',
+  _hover: {
+    bgColor: { base: 'neutral.700', _dark: 'white' },
+  },
+  _focusVisible: {
+    boxShadow: { base: '0 0 0 0.1875rem {colors.neutral.900/25}', _dark: '0 0 0 0.1875rem {colors.neutral.100/30}' },
+  },
+  _disabled: {
+    opacity: 0.55,
+    cursor: 'default',
+    _hover: {
+      bgColor: { base: 'neutral.900', _dark: 'neutral.100' },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

Reworks the Settings dialog styling for clearer visual hierarchy and a proper dark theme. The previous dark theme was hard to use: input backgrounds (`neutral.700`) matched the dialog surface, so fields only stood out via a harsh white 1px border.

## Changes

**`SettingsForm/styles.ts`**
- **Surface layering:** inputs now use `neutral.800` in dark mode so they recede from the dialog (`neutral.700`) instead of blending in.
- **Softer borders:** replace pure black/white 1px borders with `neutral.300` / `neutral.600`, plus hover states.
- **Focus rings:** add `:focus-visible` rings on inputs and the Save button — previously there was no visible focus state at all.
- **Primary Save button:** full-width solid button, inverted per theme (dark on light / light on dark), with a proper disabled state during submit.
- Muted labels for hierarchy; larger control height (`2.75rem`).

**`Modal/styles.ts`**
- Softer dialog radius (`0.75rem`) and a layered shadow instead of a flat halo.
- Even body padding; slightly narrower dialog (`28rem`).

No logic, markup, or types changed — styling only. All units are `rem`, consistent with the rest of the codebase.

## Testing
- `pnpm test` (lint + typecheck ×2 + 221 unit tests) passes.
- Verified visually in a real browser in both light and dark themes (fields, hover, focus rings, disabled Save, select chevrons).

## Screenshots
<img width="1280" height="577" alt="pr-light" src="https://github.com/user-attachments/assets/df6aa992-f2dd-4dd7-b659-f8c40e049a4a" />
<img width="1280" height="577" alt="pr-dark" src="https://github.com/user-attachments/assets/1409534b-8b29-4a97-b1b2-dfd9e3b26be7" />


