### PR TITLE
ci(release): attach build on release publish instead of tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,17 @@
 name: Release
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
 jobs:
   release:
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - uses: pnpm/action-setup@v6
       - name: Use Node.js
         uses: actions/setup-node@v6
@@ -21,7 +24,8 @@ jobs:
         run: pnpm build
       - name: Pack Chrome extension
         run: cd ./dist && zip -r ../minimal-chrome-tab.zip ./
-      - name: Publish release
-        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes ./minimal-chrome-tab.zip
+      - name: Attach build to release
+        run: gh release upload "$TAG" ./minimal-chrome-tab.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Problem

The release workflow triggered on `push: tags: ['v*']` and ran `gh release create "$TAG" --generate-notes ./minimal-chrome-tab.zip`. This has two issues:

1. **Not idempotent / collides with drafts.** `gh release create` fails if a release for the tag already exists. The natural flow — draft a release with a hand-written description in the UI, then click **Publish** — creates the tag on publish, which fires this workflow, which then tries to *create* the already-published release and fails. Result: the release ships **without** `minimal-chrome-tab.zip`, plus a red CI run.
2. **Always overwrites the description** with `--generate-notes`, so a custom release body can't survive.

## Fix

- Trigger on `release: published` instead of a tag push.
- Instead of creating the release, **upload** the built zip to the release that fired the event: `gh release upload "$TAG" ./minimal-chrome-tab.zip --clobber`. `--clobber` makes re-runs idempotent.
- The release body authored in the draft is left untouched.
- `if: startsWith(github.event.release.tag_name, 'v')` so the `nightly` pre-release (published by `nightly.yml`) is ignored.
- Explicitly check out the release tag so the build matches the tagged commit.

## New flow

1. Draft a release with a nice description.
2. Publish it → CI builds, packs, and attaches `minimal-chrome-tab.zip` to it.

## Testing
- YAML validated. No app code touched; existing `test.yml` unaffected.

> Note: `release` events run the workflow from the **default branch**, so this must be on `main` before the next release is published for it to take effect.