### PR TITLE
ci(nightly): update release in place instead of recreating it

### DIFF
--- a/.github/workflows/deploy-demo-page.yml
+++ b/.github/workflows/deploy-demo-page.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 jobs:
   build:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
 jobs:
   nighly:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -44,11 +45,20 @@ jobs:
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish nightly release
+      - name: Update nightly release
         if: steps.release_check.outputs.changed == 'true'
         run: |
-          gh release delete nightly --cleanup-tag --yes 2>/dev/null || true
-          gh release create nightly --prerelease --title "Nightly" --notes "The bleeding edge release." ./minimal-chrome-tab.zip
+          set -euo pipefail
+          # Move the rolling tag to the tested commit so the release points at latest.
+          git tag -f nightly
+          git push -f origin nightly
+          if gh release view nightly >/dev/null 2>&1; then
+            # Editing the existing release is silent — no "release published" notification.
+            gh release upload nightly ./minimal-chrome-tab.zip --clobber
+          else
+            # First run only: creating the release notifies once, then stays in place.
+            gh release create nightly --prerelease --title "Nightly" --notes "The bleeding edge release." ./minimal-chrome-tab.zip
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Skip publishing

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 on:
-  push: {}
+  push:
+    # Commits are already tested on their branch; tag pushes (e.g. the moving
+    # `nightly` tag) would only re-run the suite redundantly.
+    tags-ignore: ['**']
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
## Problem

The nightly job deleted and recreated the release on every change:

```sh
gh release delete nightly --cleanup-tag --yes
gh release create nightly --prerelease --title "Nightly" ...
```

`gh release create` publishes a brand-new release each time, so every watcher gets a **"release published" notification** on every nightly — the actual annoyance being fixed here.

## Fix

Update the existing release **in place** instead of recreating it:

- Move the rolling `nightly` tag to the tested commit (`git tag -f` + `git push -f`), so the release points at latest.
- `gh release upload nightly ./minimal-chrome-tab.zip --clobber` — editing an existing release is **silent** (no publish notification); `--clobber` keeps it idempotent.
- `gh release create` stays only as a **first-run fallback** (creating the release notifies once, then never again).

## Supporting changes

- **`test.yml`** — `tags-ignore: ['**']`. Commits are already tested on their branch; without this, the moving `nightly` tag would trigger a redundant full Test run on every nightly. (Branch pushes still run Test exactly as before.)
- **`nightly.yml` & `deploy-demo-page.yml`** — gate the job on `github.event.workflow_run.conclusion == 'success'`. Both triggered on Test `completed` **regardless of outcome**, so they could publish/deploy off a failed test run. Now they only run when Test passed.

## Notes / testing

- All three workflow files validated as YAML. No app code touched.
- The in-place tag move + `upload` path can only be fully exercised by the next real nightly run; the `gh release create` fallback covers the case where the release is ever missing.
- Depends on the release trigger from #35 already being on `main` (moving the `nightly` tag no longer collides with `release.yml`, which now listens on `release: published` guarded to `v*`).