### PR TITLE
ci(test): restore branch-push trigger broken by tags-ignore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Test
 on:
   push:
-    # Commits are already tested on their branch; tag pushes (e.g. the moving
-    # `nightly` tag) would only re-run the suite redundantly.
-    tags-ignore: ['**']
+    # Run on every branch push, but not on tag pushes — the moving `nightly`
+    # tag would otherwise re-run the suite redundantly. Filtering on `branches`
+    # (rather than `tags-ignore` alone) is what excludes tags: a `push` filter
+    # that defines only `tags-ignore` runs for tags *only*, disabling branches.
+    branches: ['**']
 jobs:
   tests:
     strategy:


### PR DESCRIPTION
## Regression

The previous CI PR (#36) set the Test workflow trigger to:

```yaml
on:
  push:
    tags-ignore: ['**']
```

Per GitHub's filter semantics, a `push` event that defines **only** `tags-ignore` (with no `branches`/`branches-ignore`) runs for **tag events only**. Combined with `**`, which ignores every tag, that disabled the Test workflow entirely — it stopped running on branch pushes.

Downstream impact: `Nightly` and `Deploy demo page` both trigger on `workflow_run: [Test] completed`, so with Test never running, that whole chain went silent. Confirmed empirically: no Test runs on the `ci/nightly-update-in-place` branch or on the `#36` merge commit on `main`.

## Fix

```yaml
on:
  push:
    branches: ['**']
```

Defining a `branches` filter runs on all branch pushes and, by the same GitHub rule, excludes tags — which was the original intent (skip the redundant run on the moving `nightly` tag) without breaking branches.

## Verification

The Test run triggered by pushing **this** branch (which already contains the corrected config) is itself the proof the trigger works again.