### PR TITLE
fix(styles): override Chrome new-tab font injection on body

### DIFF
--- a/panda.config.ts
+++ b/panda.config.ts
@@ -53,7 +53,7 @@ const keyframes = defineKeyframes({
 })
 
 export default defineConfig({
-  preflight: false,
+  preflight: true,
   importMap: 'styled-system',
   include: ['./src/**/*.{js,jsx,ts,tsx}'],
   exclude: [],
@@ -75,23 +75,20 @@ export default defineConfig({
   },
   globalCss: defineGlobalStyles({
     html: {
-      '-webkit-text-size-adjust': '100%',
-      '-webkit-tap-highlight-color': 'rgba(0, 0, 0, 0)',
-      '-webkit-font-smoothing': 'antialiased',
       fontFamily:
         "'Helvetica Neue', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'",
       fontWeight: 400,
-      boxSizing: 'border-box',
+      lineHeight: '1.2',
       background: { base: 'white', _dark: 'neutral.800' },
     },
     body: {
-      margin: 0,
-      touchAction: 'manipulation',
-      fontFamily: 'inherit',
-      fontSize: 'inherit',
-    },
-    '*, *::before, *::after': {
-      boxSizing: 'inherit',
+      // Chrome injects `font-family: system-ui; font-size: 75%` into the body of
+      // new-tab override pages as an unlayered author style, which beats Panda's
+      // layered globals. `!important` is the only reliable way to override it so
+      // the page (and Portal-mounted dialogs, which live directly under body)
+      // inherit our font instead of Chrome's.
+      fontFamily: 'inherit !important',
+      fontSize: 'inherit !important',
     },
     'html, body, #app': {
       height: 'full',


### PR DESCRIPTION
## Problem

Chrome injects its own author style `font-family: system-ui; font-size: 75%` into the `body` of new-tab override pages. It's **unlayered**, so by the cascade it beats Panda's global styles, which live in `@layer base`.

`font-size` never visually leaked — everything in the app uses `rem` (resolved against `html`). But `font-family` inherits down the DOM tree, and dialogs (`Modal` via `<Portal>`) mount **directly under `body`**, bypassing `#app` — so they inherited Chrome's font instead of ours.

## Changes

- `body { font-family/font-size: inherit !important }` — overrides Chrome's unlayered injection; the only reliable way to reach it from layered styles. A comment in the config explains why.
- Enabled Panda `preflight: true` in place of the hand-rolled resets — it covers `-webkit-font-smoothing`, `-webkit-tap-highlight-color`, `-webkit-text-size-adjust`, `box-sizing`, `margin` (and adds `-moz-osx-font-smoothing`).
- Pinned `line-height: 1.2` on `html` — preflight defaults it to 1.5, which changed line heights.

## Verification

Built and verified live in the extension: dialogs render in Helvetica Neue, line heights back to normal.